### PR TITLE
Implement Font is_monospace with dwrite1

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,6 +12,6 @@ name = "dwrote"
 [dependencies]
 libc = "0.2"
 lazy_static = "1"
-winapi = { version = "0.3", features = ["dwrite", "winnt", "unknwnbase", "libloaderapi", "winnls"] }
+winapi = { version = "0.3", features = ["dwrite", "dwrite_1", "winnt", "unknwnbase", "libloaderapi", "winnls"] }
 serde = "1.0"
 serde_derive = "1.0"

--- a/src/font.rs
+++ b/src/font.rs
@@ -11,10 +11,13 @@ use winapi::um::dwrite::{DWRITE_FONT_METRICS, DWRITE_INFORMATIONAL_STRING_FULL_N
 use winapi::um::dwrite::{DWRITE_INFORMATIONAL_STRING_POSTSCRIPT_CID_NAME};
 use winapi::um::dwrite::{DWRITE_INFORMATIONAL_STRING_POSTSCRIPT_NAME, IDWriteFontFace};
 use winapi::um::dwrite::{IDWriteLocalizedStrings, IDWriteFont, IDWriteFontFamily};
+use winapi::um::dwrite_1::IDWriteFont1;
 use std::mem;
 
 use super::*;
 use helpers::*;
+
+DEFINE_GUID!{UuidOfIDWriteFont1, 0xacd16696, 0x8c14, 0x4f5d, 0x87, 0x7e, 0xfe, 0x3f, 0xc1, 0xd3, 0x27, 0x38}
 
 pub struct Font {
     native: UnsafeCell<ComPtr<IDWriteFont>>,
@@ -55,6 +58,13 @@ impl Font {
     pub fn weight(&self) -> FontWeight {
         unsafe {
             FontWeight::from_u32((*self.native.get()).GetWeight())
+        }
+    }
+
+    pub fn is_monospace(&self) -> Option<bool> {
+        unsafe {
+            let font1: Option<ComPtr<IDWriteFont1>> = (*self.native.get()).query_interface(&UuidOfIDWriteFont1);
+            font1.map(|font| font.IsMonospacedFont() == TRUE)
         }
     }
 

--- a/src/test.rs
+++ b/src/test.rs
@@ -46,6 +46,24 @@ fn test_get_font_file_bytes() {
 }
 
 #[test]
+fn test_font_file_is_monospace() {
+    let system_fc = FontCollection::system();
+
+    let arial_family = system_fc.get_font_family_by_name("Arial").unwrap();
+    let arial_font = arial_family.get_first_matching_font(FontWeight::Regular,
+                                                          FontStretch::Normal,
+                                                          FontStyle::Normal);
+    assert!(arial_font.is_monospace() == Some(false));
+
+    let courier_new_family = system_fc.get_font_family_by_name("Courier New").unwrap();
+    let courier_new_font = courier_new_family.get_first_matching_font(FontWeight::Regular,
+                                                          FontStretch::Normal,
+                                                          FontStyle::Normal);
+    assert!(courier_new_font.is_monospace() == Some(true));
+}
+
+
+#[test]
 fn test_create_font_file_from_bytes() {
     let system_fc = FontCollection::system();
 


### PR DESCRIPTION
I kind of assumed that winapi would give you the GUID somehow, but I couldn't figure out how to do that.